### PR TITLE
added ESP32 support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,11 +17,27 @@ monitor_speed = 115200
 build_flags = 
 	-D NUM_LEDS=30
 	-D PIN_LEDS=3
-	-D STATUS_LED_DELAY=60000   ;a green "I'm alive" signal will blink the 4th LED in the strip. Set to -1 to not see this blink at all
-
+	-D STATUS_LED_DELAY=60000
 lib_deps = 
 	knolleary/PubSubClient @ ^2.8
 	tzapu/WiFiManager@^0.16.0
+	khoih.prog/ESP_DoubleResetDetector@^1.1.1
+	fastled/FastLED@^3.4.0
+	bblanchon/ArduinoJson@^6.18.0
+
+[env:esp32]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+build_flags = 
+	-D NUM_LEDS=30
+	-D PIN_LEDS=3
+	-D STATUS_LED_DELAY=60000
+	-D ESP_DRD_USE_SPIFFS=true
+lib_deps = 
+	knolleary/PubSubClient @ ^2.8
+	https://github.com/tzapu/WiFiManager.git
 	khoih.prog/ESP_DoubleResetDetector@^1.1.1
 	fastled/FastLED@^3.4.0
 	bblanchon/ArduinoJson@^6.18.0


### PR DESCRIPTION
Added ESP32 support, had to do some adjustments for the code.
Couldn't check it myself because we don't have alarms anymore :)

Used defines to switch between platforms during compilation, changed drd to pointer type in order to use it with SPIFFS (for ESP32, instead of EEPROM).

In the future, we can implement BLE provisioning in order to config the WiFi and area list (can use the esp-idf provisioning).